### PR TITLE
Fix endOf, daysInMonth, subtract and calendar persistence issues

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -129,11 +129,7 @@ export default (o, Dayjs, dayjs) => {
     }
   }
 
-  /**
-   * $set is called in private inside dayjs itself.
-   */
-  proto.$set = function (units, int) {
-    // private set
+  proto.$set = function (units, int) { // private set
     if (!this.isJalali()) {
       return old$Set.bind(this)(units, int)
     }
@@ -151,11 +147,6 @@ export default (o, Dayjs, dayjs) => {
         innerSetDate(int, this.$jM)
         break
       case C.M:
-        // The following is for the edge case where month minus int results in
-        // negative year change. For example if monthIndex is 0 (Farvardin in
-        // jalali) and subtract is called with (1, 'month'), the int here will
-        // be -1 (0 - 1), and jdate doesn't support negative numbers very well.
-        // This way the edge case can be handled more gracefully.
         innerSetDate(this.$jD, int)
         break
       case C.Y:

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -68,7 +68,6 @@ export default (o, Dayjs, dayjs) => {
   proto.init = function (cfg = {}) {
     oldInit.bind(this)(cfg)
 
-    this.$C = cfg.calendar || this.$C || dayjs.$C
     if (this.isJalali()) {
       this.InitJalali()
     }
@@ -76,6 +75,7 @@ export default (o, Dayjs, dayjs) => {
 
   proto.parse = function (cfg) {
     let reg
+    this.$C = cfg.calendar || this.$C || dayjs.$C
     // eslint-disable-next-line no-cond-assign
     if (cfg.jalali && (typeof cfg.date === 'string') &&
       (/.*[^Z]$/i.test(cfg.date)) && // looking for a better way
@@ -134,7 +134,7 @@ export default (o, Dayjs, dayjs) => {
       return old$Set.bind(this)(units, int)
     }
     const unit = U.prettyUnit(units)
-    const instanceFactory = (d, m, y = this.$jy) => {
+    const innerSetDate = (d, m, y = this.$jy) => {
       const [gy, gm, gd] = jdate.toGregorian(y, m + 1, d)
       this.$d.setDate(gd)
       this.$d.setMonth(gm - 1)
@@ -143,13 +143,13 @@ export default (o, Dayjs, dayjs) => {
     }
     switch (unit) {
       case C.DATE:
-        instanceFactory(int, this.$jM)
+        innerSetDate(int, this.$jM)
         break
       case C.M:
-        instanceFactory(this.$jD, int)
+        innerSetDate(this.$jD, int === -1 ? 11 : int, int === -1 ? this.$jy - 1 : this.$jy)
         break
       case C.Y:
-        instanceFactory(this.$jD, this.$jM, int)
+        innerSetDate(this.$jD, this.$jM, int)
         break
       default:
         return old$Set.bind(this)(units, int)

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -116,7 +116,11 @@ export default (o, Dayjs, dayjs) => {
           : instanceFactory(0, 0, this.$jy + 1)
       case C.M:
         return isStartOf ? instanceFactory(1, this.$jM)
-          : instanceFactory(0, this.$jM + 1)
+          : instanceFactory(
+            0,
+            this.$jM + 1 >= 12 ? 0 : this.$jM + 1,
+            this.$jM + 1 >= 12 ? this.$jy + 1 : this.$jy
+          )
       case C.W:
         return isStartOf ? instanceFactory(this.$jD - WModifier, this.$jM)
           : instanceFactory(this.$jD + (6 - WModifier), this.$jM)

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,4 +1,3 @@
-
 import MockDate from 'mockdate'
 import dayjs from 'dayjs'
 import jalali from '../src'
@@ -262,6 +261,14 @@ describe('subtract', () => {
     expect(date2.date()).toEqual(date.date())
   })
 
+  test('add 11 months in the middle of the year', () => {
+    const date = dayjs('1396/06/13', { jalali: true })
+    const date2 = date.add(11, 'month')
+    expect(date2.year()).toEqual(date.year() + 1)
+    expect(date2.month()).toEqual(date.month() - 1)
+    expect(date2.date()).toEqual(date.date())
+  })
+
   test('subtract 18 months', () => {
     const date = dayjs('1397/06/13', { jalali: true })
     const date2 = date.subtract(18, 'month')
@@ -269,7 +276,7 @@ describe('subtract', () => {
     expect(date2.month()).toEqual(11)
     expect(date2.date()).toEqual(date.date())
   })
-  
+
   test('subtract 17 months', () => {
     const date = dayjs('1397/06/13', { jalali: true })
     const date2 = date.subtract(17, 'month')
@@ -283,6 +290,14 @@ describe('subtract', () => {
     const date2 = date.subtract(1, 'month')
     expect(date2.year()).toEqual(date.year() - 1)
     expect(date2.month()).toEqual(11)
+    expect(date2.date()).toEqual(date.date())
+  })
+
+  test('subtract 1 month in the beginning of the year', () => {
+    const date = dayjs('1397/01/01', { jalali: true })
+    const date2 = date.subtract(11, 'month')
+    expect(date2.year()).toEqual(date.year() - 1)
+    expect(date2.month()).toEqual(1)
     expect(date2.date()).toEqual(date.date())
   })
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -30,6 +30,14 @@ describe('Parse Valid String', () => {
     expect(date.date()).toEqual(13)
   })
 
+  const date2 = dayjs('1397/06', { jalali: true })
+
+  test('valid jalali date without day', () => {
+    expect(date2.year()).toEqual(1397)
+    expect(date2.month()).toEqual(5)
+    expect(date2.date()).toEqual(1)
+  })
+
   const gregory = date.calendar('gregory')
 
   test('convert to gregory', () => {
@@ -55,12 +63,60 @@ it('startOfMonth', () => {
   expect(date2.date()).toEqual(1)
 })
 
+it('endOfMonth - months with 31 days', () => {
+  const date = dayjs('1397/06/13', { jalali: true })
+  const date2 = date.endOf('month')
+  expect(date2.year()).toEqual(date.year())
+  expect(date2.month()).toEqual(date.month())
+  expect(date2.date()).toEqual(31)
+})
+
+it('endOfMonth - months with 30 days', () => {
+  const date = dayjs('1397/07/13', { jalali: true })
+  const date2 = date.endOf('month')
+  expect(date2.year()).toEqual(date.year())
+  expect(date2.month()).toEqual(date.month())
+  expect(date2.date()).toEqual(30)
+})
+
+it('endOfMonth - months with 29 days', () => {
+  const date = dayjs('1397/12/13', { jalali: true })
+  const date2 = date.endOf('month')
+  expect(date2.year()).toEqual(date.year())
+  expect(date2.month()).toEqual(date.month())
+  expect(date2.date()).toEqual(29)
+})
+
+it('endOfMonth - months with 29 days - leap year', () => {
+  const date = dayjs('1399/12/13', { jalali: true })
+  const date2 = date.endOf('month')
+  expect(date2.year()).toEqual(date.year())
+  expect(date2.month()).toEqual(date.month())
+  expect(date2.date()).toEqual(30)
+})
+
 it('startOfYear', () => {
   const date = dayjs('1397/06/13', { jalali: true })
   const date2 = date.startOf('year')
   expect(date2.year()).toEqual(date.year())
   expect(date2.month()).toEqual(0)
   expect(date2.date()).toEqual(1)
+})
+
+it('endOfYear', () => {
+  const date = dayjs('1397/06/13', { jalali: true })
+  const date2 = date.endOf('year')
+  expect(date2.year()).toEqual(date.year())
+  expect(date2.month()).toEqual(11)
+  expect(date2.date()).toEqual(29)
+})
+
+it('endOfYear - leap year', () => {
+  const date = dayjs('1399/06/13', { jalali: true })
+  const date2 = date.endOf('year')
+  expect(date2.year()).toEqual(date.year())
+  expect(date2.month()).toEqual(11)
+  expect(date2.date()).toEqual(30)
 })
 
 it('startOfWeek', () => {
@@ -75,10 +131,31 @@ it('endOfWeek', () => {
   expect(date2.day()).toEqual(5)
 })
 
+it('dayInMonth, months with 31 days', () => {
+  expect(dayjs('1397/06/13', { jalali: true }).daysInMonth()).toEqual(31)
+  expect(dayjs('1396/05/13', { jalali: true }).daysInMonth()).toEqual(31)
+  expect(dayjs('1395/04/13', { jalali: true }).daysInMonth()).toEqual(31)
+  expect(dayjs('1393/03/13', { jalali: true }).daysInMonth()).toEqual(31)
+  expect(dayjs('1392/02/13', { jalali: true }).daysInMonth()).toEqual(31)
+  expect(dayjs('1391/01/13', { jalali: true }).daysInMonth()).toEqual(31)
+})
 
-it('dayInMonth', () => {
-  const date = dayjs('1397/06/13', { jalali: true })
-  expect(date.daysInMonth()).toEqual(31)
+it('dayInMonth, months with 30 days', () => {
+  expect(dayjs('1397/11/13', { jalali: true }).daysInMonth()).toEqual(30)
+  expect(dayjs('1396/10/13', { jalali: true }).daysInMonth()).toEqual(30)
+  expect(dayjs('1395/09/13', { jalali: true }).daysInMonth()).toEqual(30)
+  expect(dayjs('1394/08/13', { jalali: true }).daysInMonth()).toEqual(30)
+  expect(dayjs('1393/07/13', { jalali: true }).daysInMonth()).toEqual(30)
+})
+
+it('dayInMonth - months with 29 days in leap years', () => {
+  const date = dayjs('1399/12/13', { jalali: true })
+  expect(date.daysInMonth()).toEqual(30)
+})
+
+it('dayInMonth - months with 29 days', () => {
+  const date = dayjs('1397/12/13', { jalali: true })
+  expect(date.daysInMonth()).toEqual(29)
 })
 
 it('format', () => {
@@ -134,4 +211,3 @@ describe('diff two date', () => {
     expect(a.diff(b, 'year')).toEqual(0)
   })
 })
-

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -269,6 +269,14 @@ describe('subtract', () => {
     expect(date2.month()).toEqual(11)
     expect(date2.date()).toEqual(date.date())
   })
+  
+  test('subtract 17 months', () => {
+    const date = dayjs('1397/06/13', { jalali: true })
+    const date2 = date.subtract(17, 'month')
+    expect(date2.year()).toEqual(1396)
+    expect(date2.month()).toEqual(0)
+    expect(date2.date()).toEqual(date.date())
+  })
 
   test('subtract 1 month in the beginning of the year', () => {
     const date = dayjs('1397/01/13', { jalali: true })

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -262,6 +262,14 @@ describe('subtract', () => {
     expect(date2.date()).toEqual(date.date())
   })
 
+  test('subtract 18 months', () => {
+    const date = dayjs('1397/06/13', { jalali: true })
+    const date2 = date.subtract(18, 'month')
+    expect(date2.year()).toEqual(1395)
+    expect(date2.month()).toEqual(11)
+    expect(date2.date()).toEqual(date.date())
+  })
+
   test('subtract 1 month in the beginning of the year', () => {
     const date = dayjs('1397/01/13', { jalali: true })
     const date2 = date.subtract(1, 'month')

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -20,6 +20,18 @@ it('Extend dayjs', () => {
   expect(dayjs().$jy).toBeDefined()
 })
 
+it('Setting calendar converts date', () => {
+  const date = dayjs('1397/06/13', { jalali: true }).calendar('gregory')
+  expect(date.$y).toEqual(2018)
+  expect(date.$M).toEqual(8)
+  expect(date.$D).toEqual(4)
+
+  const date2 = dayjs('2018/09/04').calendar('jalali')
+  expect(date2.$jy).toEqual(1397)
+  expect(date2.$jM).toEqual(5)
+  expect(date2.$jD).toEqual(13)
+})
+
 describe('Parse Valid String', () => {
   // 2018-09-04
   const date = dayjs('1397/06/13', { jalali: true })
@@ -159,11 +171,16 @@ it('dayInMonth - months with 29 days', () => {
 })
 
 it('format', () => {
+  expect(dayjs('2018/09/03').calendar('gregory').format('YYYY/MM/DD')).toEqual('2018/09/03')
+
   const date = dayjs('1397/06/13', { jalali: true })
+  expect(date.format()).toEqual('1397-06-13T00:00:00+04:30')
+  expect(date.format('[Unformatted text]')).toEqual('Unformatted text')
   expect(date.format('YY')).toEqual(String(97))
   expect(date.format('YYYY')).toEqual(String(1397))
   expect(date.format('M')).toEqual('6')
   expect(date.format('MM')).toEqual('06')
+  expect(date.format('MMM')).toEqual('Sha')
   expect(date.format('MMMM')).toEqual('Shahrivar')
   expect(date.locale('fa').format('MMMM')).toEqual('شهریور')
   expect(date.format('DD')).toEqual('13')
@@ -187,12 +204,11 @@ describe('add two date', () => {
 })
 
 describe('diff two date', () => {
-  let a = null
-  let b = null
+  const a = dayjs('1397/06/01', { jalali: true })
+  const b = dayjs('1397/09/10', { jalali: true })
 
-  beforeEach(() => {
-    a = dayjs('1397/06/01', { jalali: true })
-    b = dayjs('1397/09/10', { jalali: true })
+  it('diff(float)', () => {
+    expect(a.diff(b, 'month', true)).toEqual(-3.3)
   })
 
   it('diff(month)', () => {
@@ -209,5 +225,110 @@ describe('diff two date', () => {
 
   it('diff(year)', () => {
     expect(a.diff(b, 'year')).toEqual(0)
+  })
+})
+
+describe('subtract', () => {
+  test('subtract 1 ms', () => {
+    const date = dayjs('1397/06/13', { jalali: true })
+    const date2 = date.subtract(1, 'ms')
+    expect(date2.year()).toEqual(date.year())
+    expect(date2.month()).toEqual(date.month())
+    expect(date2.date()).toEqual(date.date() - 1)
+    expect(date2.$ms).toEqual(999)
+  })
+
+  test('subtract 1 day in the middle of the month', () => {
+    const date = dayjs('1397/06/13', { jalali: true })
+    const date2 = date.subtract(1, 'day')
+    expect(date2.year()).toEqual(date.year())
+    expect(date2.month()).toEqual(date.month())
+    expect(date2.date()).toEqual(date.date() - 1)
+  })
+
+  test('subtract 1 day in the beginning of the month', () => {
+    const date = dayjs('1397/06/01', { jalali: true })
+    const date2 = date.subtract(1, 'day')
+    expect(date2.year()).toEqual(date.year())
+    expect(date2.month()).toEqual(date.month() - 1)
+    expect(date2.date()).toEqual(31)
+  })
+
+  test('subtract 1 month in the middle of the year', () => {
+    const date = dayjs('1397/06/13', { jalali: true })
+    const date2 = date.subtract(1, 'month')
+    expect(date2.year()).toEqual(date.year())
+    expect(date2.month()).toEqual(date.month() - 1)
+    expect(date2.date()).toEqual(date.date())
+  })
+
+  test('subtract 1 month in the beginning of the year', () => {
+    const date = dayjs('1397/01/13', { jalali: true })
+    const date2 = date.subtract(1, 'month')
+    expect(date2.year()).toEqual(date.year() - 1)
+    expect(date2.month()).toEqual(11)
+    expect(date2.date()).toEqual(date.date())
+  })
+
+  test('subtract 1 year', () => {
+    const date = dayjs('1397/01/13', { jalali: true })
+    const date2 = date.subtract(1, 'year')
+    expect(date2.year()).toEqual(date.year() - 1)
+    expect(date2.month()).toEqual(date.month())
+    expect(date2.date()).toEqual(date.date())
+  })
+})
+
+describe('add', () => {
+  test('add 1 day in the middle of the month', () => {
+    const date = dayjs('1397/06/13', { jalali: true })
+    const date2 = date.add(1, 'day')
+    expect(date2.year()).toEqual(date.year())
+    expect(date2.month()).toEqual(date.month())
+    expect(date2.date()).toEqual(date.date() + 1)
+  })
+
+  test('add 1 day in the end of the month', () => {
+    const date = dayjs('1397/06/31', { jalali: true })
+    const date2 = date.add(1, 'day')
+    expect(date2.year()).toEqual(date.year())
+    expect(date2.month()).toEqual(date.month() + 1)
+    expect(date2.date()).toEqual(1)
+  })
+
+  test('add 1 month in the middle of the year', () => {
+    const date = dayjs('1397/06/13', { jalali: true })
+    const date2 = date.add(1, 'month')
+    expect(date2.year()).toEqual(date.year())
+    expect(date2.month()).toEqual(date.month() + 1)
+    expect(date2.date()).toEqual(date.date())
+  })
+
+  test('add 1 month in the end of the year', () => {
+    const date = dayjs('1397/12/13', { jalali: true })
+    const date2 = date.add(1, 'month')
+    expect(date2.year()).toEqual(date.year() + 1)
+    expect(date2.month()).toEqual(0)
+    expect(date2.date()).toEqual(date.date())
+  })
+
+  test('add 1 year', () => {
+    const date = dayjs('1397/12/13', { jalali: true })
+    const date2 = date.add(1, 'year')
+    expect(date2.year()).toEqual(date.year() + 1)
+    expect(date2.month()).toEqual(date.month())
+    expect(date2.date()).toEqual(date.date())
+  })
+})
+
+describe('toArray', () => {
+  test('Convert date to array', () => {
+    const date = dayjs('2018/09/03').calendar('gregory')
+    expect(date.toArray()).toEqual([2018, 8, 3, 0, 0, 0, 0])
+  })
+
+  test('Convert date to array', () => {
+    const date = dayjs('1397/06/13', { jalali: true })
+    expect(date.toArray()).toEqual([1397, 5, 13, 0, 0, 0, 0])
   })
 })


### PR DESCRIPTION
UPDATE: Sorry my previous commit (removed by force push) didn't solve the problem. Also removed the PR note so this one is the new one.

- Fixed Esfand's `endOf` and `daysInMonth` functionality
- Fixed calendar persistence issue in some edge cases
- Fixed Farvardin's `subtract` issue
- Added tests

### Issues fixed

- fixes #7 

### Tests

```
 PASS  test/plugin.test.js
 PASS  test/relaiable-calendar-change.test.js
-------------|----------|----------|----------|----------|-------------------|
File         |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------|----------|----------|----------|----------|-------------------|
All files    |    98.15 |       96 |    97.06 |    98.13 |                   |
 calendar.js |    95.35 |    84.62 |      100 |    95.35 |           123,132 |
 constant.js |       90 |      100 |        0 |       90 |                17 |
 index.js    |      100 |      100 |      100 |      100 |                   |
 plugin.js   |    99.39 |    98.99 |      100 |    99.38 |               155 |
-------------|----------|----------|----------|----------|-------------------|
```

![image](https://user-images.githubusercontent.com/14017717/53982557-74788c80-412a-11e9-8c80-18097d27759f.png)
