### PR TITLE
fix(utc): add utc property to wrapper

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -66,6 +66,7 @@ export default (o, Dayjs, dayjs) => {
   const wrapper = function (date, instance) {
     return dayjs(date, {
       locale: instance.$L,
+      utc: instance.$u,
       calendar: instance.$C
     })
   }

--- a/test/plugin.utc.test.js
+++ b/test/plugin.utc.test.js
@@ -1,0 +1,12 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import jalali from '../src'
+
+dayjs.extend(utc)
+dayjs.extend(jalali)
+
+it('Should respect utc', () => {
+  const date = dayjs.utc().calendar('jalali')
+
+  expect(date.isUTC()).toBe(true)
+})


### PR DESCRIPTION
Currently, jalaliday doesn't work with the UTC plugin. For example, when we change the calendar of a UTC date, the timezone returns. This PR is based on [dayjs original wrapper](https://github.com/iamkun/dayjs/blob/dev/src/index.js#L44) to pass the `utc` property to the new instance.