### PR TITLE
feat(weekday): support weekday plugin

### DIFF
--- a/bili.config.js
+++ b/bili.config.js
@@ -8,5 +8,6 @@ module.exports = {
       'umd-min'
     ],
     sourceMap: false
-  }
+  },
+  externals: ['dayjs']
 }

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
   },
   "size-limit": [
     {
-      "limit": "5.40 KB",
-      "path": "dist/jalaliday.umd.min.js"
+      "limit": "2.99 KB",
+      "path": "dist/jalaliday.umd.min.js",
+      "ignore": ["dayjs"]
     },
     {
-      "limit": "5.30 KB",
-      "path": "dist/jalaliday.cjs.min.js"
+      "limit": "2.99 KB",
+      "path": "dist/jalaliday.cjs.min.js",
+      "ignore": ["dayjs"]
     }
   ],
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   },
   "size-limit": [
     {
-      "limit": "2.99 KB",
+      "limit": "5.40 KB",
       "path": "dist/jalaliday.umd.min.js"
     },
     {
-      "limit": "2.99 KB",
+      "limit": "5.30 KB",
       "path": "dist/jalaliday.cjs.min.js"
     }
   ],

--- a/src/constant.js
+++ b/src/constant.js
@@ -12,9 +12,21 @@ export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 export const fa = {
   name: 'fa',
   weekdays: 'یک‌شنبه_دوشنبه_سه‌شنبه_چهارشنبه_پنج‌شنبه_جمعه_شنبه'.split('_'),
+  weekdaysShort: 'یک‌شنبه_دوشنبه_سه‌شنبه_چهارشنبه_پنج‌شنبه_جمعه_شنبه'.split('_'),
+  weekdaysMin: 'ی_د_س_چ_پ_ج_ش'.split('_'),
+  weekStart: 6,
   months: 'ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر'.split('_'),
+  monthsShort: 'ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر'.split('_'),
   jmonths: 'فروردین_اردیبهشت_خرداد_تیر_مرداد_شهریور_مهر_آبان_آذر_دی_بهمن_اسفند'.split('_'),
   ordinal: (n) => n,
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  },
   relativeTime: {
     future: 'در %s ثانیه‌ی آتی',
     past: '%s پیش',

--- a/src/constant.js
+++ b/src/constant.js
@@ -10,36 +10,5 @@ export const W = 'week'
 export const FORMAT_DEFAULT = 'YYYY-MM-DDTHH:mm:ssZ'
 
 export const fa = {
-  name: 'fa',
-  weekdays: 'یک‌شنبه_دوشنبه_سه‌شنبه_چهارشنبه_پنج‌شنبه_جمعه_شنبه'.split('_'),
-  weekdaysShort: 'یک‌شنبه_دوشنبه_سه‌شنبه_چهارشنبه_پنج‌شنبه_جمعه_شنبه'.split('_'),
-  weekdaysMin: 'ی_د_س_چ_پ_ج_ش'.split('_'),
-  weekStart: 6,
-  months: 'ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر'.split('_'),
-  monthsShort: 'ژانویه_فوریه_مارس_آوریل_مه_ژوئن_ژوئیه_اوت_سپتامبر_اکتبر_نوامبر_دسامبر'.split('_'),
-  jmonths: 'فروردین_اردیبهشت_خرداد_تیر_مرداد_شهریور_مهر_آبان_آذر_دی_بهمن_اسفند'.split('_'),
-  ordinal: (n) => n,
-  formats: {
-    LT: 'HH:mm',
-    LTS: 'HH:mm:ss',
-    L: 'DD/MM/YYYY',
-    LL: 'D MMMM YYYY',
-    LLL: 'D MMMM YYYY HH:mm',
-    LLLL: 'dddd, D MMMM YYYY HH:mm'
-  },
-  relativeTime: {
-    future: 'در %s ثانیه‌ی آتی',
-    past: '%s پیش',
-    s: 'چند ثانیه پیش',
-    m: 'یک دقیقه',
-    mm: '%d دقیقه',
-    h: 'یک ساعت',
-    hh: '%d ساعت',
-    d: 'یک روز',
-    dd: '%d روز',
-    M: 'یک ماه',
-    MM: '%d ماه',
-    y: 'یک سال',
-    yy: '%d سال'
-  }
+  jmonths: 'فروردین_اردیبهشت_خرداد_تیر_مرداد_شهریور_مهر_آبان_آذر_دی_بهمن_اسفند'.split('_')
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,3 +1,5 @@
+import fa from 'dayjs/locale/fa'
+
 import jdate from './calendar'
 import * as C from './constant'
 
@@ -61,7 +63,7 @@ export default (o, Dayjs, dayjs) => {
   }
 
   dayjs.en.jmonths = 'Farvardin_Ordibehesht_Khordaad_Tir_Mordaad_Shahrivar_Mehr_Aabaan_Aazar_Dey_Bahman_Esfand'.split('_')
-  dayjs.locale('fa', C.fa, true)
+  dayjs.locale('fa', { ...fa, ...C.fa }, true)
 
   const wrapper = function (date, instance) {
     return dayjs(date, {

--- a/test/plugin.weekday.test.js
+++ b/test/plugin.weekday.test.js
@@ -1,0 +1,14 @@
+import dayjs from 'dayjs'
+import weekday from 'dayjs/plugin/weekday'
+import jalali from '../src'
+
+dayjs.extend(weekday)
+dayjs.extend(jalali)
+
+it('Should return correct weekday', () => {
+  // پنج‌شنبه ۱ اسفند ۱۳۹۸
+  const date = dayjs('1398-12-01', { jalali: true }).locale('fa')
+
+  expect(date.day()).toBe(4)
+  expect(date.weekday()).toBe(5)
+})


### PR DESCRIPTION
Dayjs [weekday plugin](https://day.js.org/docs/en/plugin/week-day) uses `weekStart` property in the locale config which is not provided currently.

This PR tries to sync the locale config with the [official `fa` locale](https://github.com/iamkun/dayjs/blob/dev/src/locale/fa.js).

The appropriate test is added for weekday plugin as well.