### PR TITLE
fix: use ESM version of locale

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,4 +1,4 @@
-import fa from 'dayjs/locale/fa'
+import fa from 'dayjs/esm/locale/fa'
 
 import jdate from './calendar'
 import * as C from './constant'


### PR DESCRIPTION
Hi,

Thanks for this great package.

There is some bugs using it with non-bundlers like vite or snowpack, ESM version imports none esm version of locales in dayjs
I made the changes thanks a lot.